### PR TITLE
fix: Align Shown Messages with Twiga

### DIFF
--- a/app/actions/messages.ts
+++ b/app/actions/messages.ts
@@ -33,6 +33,11 @@ export async function getMessages(limit: number = 100): Promise<{
 
     const dbMessages = await db.query.messages.findMany({
       limit,
+      where: (messages, { and, eq, or }) =>
+        and(
+          eq(messages.is_present_in_conversation, true),
+          or(eq(messages.role, "user"), eq(messages.role, "assistant"))
+        ),
       orderBy: (messages, { desc }) => [desc(messages.created_at)],
     })
 

--- a/components/ChatContainer.tsx
+++ b/components/ChatContainer.tsx
@@ -30,10 +30,9 @@ export const ChatContainer = ({
 
   console.log("Messages in container :", messages)
 
-  // Filter out empty non-tool messages
+  // Filter out empty messages.
   const validMessages = useMemo(() => {
     return messages.filter((msg) => {
-      if (msg.role === "tool") return true
       return msg.content && msg.content.trim() !== ""
     })
   }, [messages])

--- a/components/ChatMessage.tsx
+++ b/components/ChatMessage.tsx
@@ -3,7 +3,7 @@ import { format } from "date-fns"
 import { Check, CheckCheck } from "lucide-react"
 
 import { type Message } from "@/types/chat"
-import { cn, formatToolName } from "@/lib/utils"
+import { cn } from "@/lib/utils"
 
 interface ChatMessageProps {
   message: Message
@@ -23,7 +23,6 @@ const areEqual = (prevProps: ChatMessageProps, nextProps: ChatMessageProps) => {
 const ChatMessageComponent = ({ message }: ChatMessageProps) => {
   console.log("Message :", message)
   const isSender = message.role === "user"
-  const isTool = message.role === "tool"
   const isTemporary = message.isTemp === true
 
   // State for fading animation
@@ -81,14 +80,9 @@ const ChatMessageComponent = ({ message }: ChatMessageProps) => {
     }
   }, [isSender, message.status])
 
-  // Format the tool name nicely if present
-  const formattedToolName = useMemo(() => {
-    return formatToolName(message.tool_name)
-  }, [message.tool_name])
-
-  // Early return for empty non-tool messages - don't render them at all
-  // This comes AFTER all hook calls to avoid the React Hook rule violation
-  if (!isTool && isEmptyContent) {
+  // Early return for empty messages - don't render them at all.
+  // This comes AFTER all hook calls to avoid the React Hook rule violation.
+  if (isEmptyContent) {
     return null
   }
 
@@ -113,17 +107,7 @@ const ChatMessageComponent = ({ message }: ChatMessageProps) => {
           }`}
         >
           <p className="break-words text-[15px] leading-relaxed">
-            {isTool && (
-              <span className="mb-1 block font-medium">
-                ⚙️ Using tool :
-                {message.tool_name && (
-                  <span className="ml-1 inline-block rounded-md bg-blue-100 px-1.5 py-0.5 text-sm font-semibold text-blue-700">
-                    {formattedToolName}
-                  </span>
-                )}
-              </span>
-            )}
-            {!isTool && message.content && <span>{message.content}</span>}
+            {message.content && <span>{message.content}</span>}
           </p>
           <div className="-mb-1 flex items-center justify-end space-x-1">
             <span className="text-xs text-muted-foreground">

--- a/components/ClientChatInterface.tsx
+++ b/components/ClientChatInterface.tsx
@@ -273,11 +273,10 @@ export default function ClientChatInterface({
     setIsAutoScrollEnabled(isAtBottom)
   }
 
-  // Filter to only show user, assistant messages and tool messages
+  // Filter to only show user and assistant messages.
   const filterAllowedRoles = (msgs: Message[]): Message[] => {
     return msgs.filter(
-      (msg) =>
-        msg.role === "user" || msg.role === "assistant" || msg.role === "tool"
+      (msg) => msg.role === "user" || msg.role === "assistant"
     )
   }
 

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,5 +1,12 @@
 import { sql } from "drizzle-orm"
-import { pgTable, serial, text, timestamp, varchar } from "drizzle-orm/pg-core"
+import {
+  boolean,
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  varchar,
+} from "drizzle-orm/pg-core"
 
 // Define MessageRole enum to match Python enum
 export const MessageRole = {
@@ -16,6 +23,9 @@ export const messages = pgTable("messages", {
   role: varchar("role", { length: 20 }).notNull(),
   content: text("content"),
   tool_name: varchar("tool_name", { length: 255 }),
+  is_present_in_conversation: boolean("is_present_in_conversation")
+    .notNull()
+    .default(true),
   created_at: timestamp("created_at", { withTimezone: true })
     .default(sql`now()`)
     .notNull(),


### PR DESCRIPTION
Twiga has added a new field called `is_present_in_conversation` to the Messages table. This field is capturing all possible messages sent to the real user using the real whatsapp so that we can keep track of it. This means that we also needed to align this repository for local testing.