### PR TITLE
feat: add an observe mode to check how users interact

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,17 @@ pnpm install
 
 # Start the development server
 pnpm run dev
+
+# Start the read-only observer mode
+pnpm run observe
 ```
+
+When running `pnpm run observe`, the app prompts for a numeric `userId` and
+only loads messages from the `messages` table that:
+
+- belong to that `user_id`
+- have `is_present_in_conversation = true`
+- have a `user` or `assistant` role
 
 ## 📝 Configuration
 

--- a/app/actions/messages.ts
+++ b/app/actions/messages.ts
@@ -1,7 +1,11 @@
 "use server"
 
 import { db } from "@/db"
-
+import {
+  buildMessagesFindManyOptions,
+  formatDbMessage,
+  type GetMessagesOptions,
+} from "@/lib/messageQuery"
 import { type Message } from "@/types/chat"
 
 /**
@@ -18,7 +22,7 @@ function isConnectionError(error: unknown): boolean {
   )
 }
 
-export async function getMessages(limit: number = 100): Promise<{
+export async function getMessages(options: GetMessagesOptions = {}): Promise<{
   messages: Message[]
   error?: string
 }> {
@@ -31,15 +35,9 @@ export async function getMessages(limit: number = 100): Promise<{
       }
     }
 
-    const dbMessages = await db.query.messages.findMany({
-      limit,
-      where: (messages, { and, eq, or }) =>
-        and(
-          eq(messages.is_present_in_conversation, true),
-          or(eq(messages.role, "user"), eq(messages.role, "assistant"))
-        ),
-      orderBy: (messages, { desc }) => [desc(messages.created_at)],
-    })
+    const dbMessages = await db.query.messages.findMany(
+      buildMessagesFindManyOptions(options)
+    )
 
     // Always return an array, even if empty
     if (!dbMessages) {
@@ -47,17 +45,7 @@ export async function getMessages(limit: number = 100): Promise<{
       return { messages: [] }
     }
 
-    const formattedMessages: Message[] = dbMessages.map((msg) => ({
-      id: msg.id ?? crypto.randomUUID(),
-      role: msg.role as Message["role"],
-      content: msg.content ?? "",
-      tool_name: msg.tool_name ?? null,
-      created_at: msg.created_at,
-      timestamp: msg.created_at
-        ? Math.floor(new Date(msg.created_at).getTime() / 1000)
-        : Math.floor(Date.now() / 1000),
-      status: "sent",
-    }))
+    const formattedMessages: Message[] = dbMessages.map(formatDbMessage)
 
     return { messages: formattedMessages }
   } catch (error) {

--- a/app/actions/whatsapp.ts
+++ b/app/actions/whatsapp.ts
@@ -2,6 +2,8 @@
 
 import { revalidatePath } from "next/cache"
 
+import { getAppMode } from "@/lib/appMode"
+
 import { env } from "../../env.js"
 
 interface SendMessageProps {
@@ -17,6 +19,13 @@ export async function sendWhatsAppMessage({
   recipientId = "255712345678",
 }: SendMessageProps) {
   try {
+    if (getAppMode() === "observe") {
+      return {
+        success: false,
+        error: "OBSERVE_MODE_READ_ONLY",
+      }
+    }
+
     // Create the WhatsApp Business API payload format
     const payload = {
       object: "whatsapp_business_account",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,95 @@
 import { Suspense } from "react"
 import { Loader2 } from "lucide-react"
 
+import { getAppMode, parseObservedUserId } from "@/lib/appMode"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 import ClientChatInterface from "@/components/ClientChatInterface"
 
 import { getMessages } from "./actions/messages"
 
-export default async function Home() {
-  // Prefetch messages server-side
-  const response = await getMessages()
+interface HomeProps {
+  searchParams?: Promise<{
+    userId?: string | string[]
+  }>
+}
+
+function ObserveUserLookup({
+  error,
+  userIdValue,
+}: {
+  error?: string
+  userIdValue?: string
+}) {
+  return (
+    <div className="flex min-h-screen items-center justify-center px-6 py-10">
+      <div className="w-full max-w-md rounded-3xl bg-primary-foreground p-8 shadow-lg">
+        <div className="space-y-2">
+          <p className="text-sm font-medium uppercase tracking-[0.2em] text-primary">
+            Observe Mode
+          </p>
+          <h1 className="text-2xl font-semibold text-foreground">
+            Load a user conversation
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            This mode only reads messages from the database and never sends
+            WhatsApp messages.
+          </p>
+        </div>
+
+        <form method="get" className="mt-6 space-y-4">
+          <Input
+            name="userId"
+            inputMode="numeric"
+            placeholder="Enter a user ID"
+            defaultValue={userIdValue}
+          />
+          {error ? <p className="text-sm text-red-600">{error}</p> : null}
+          <Button type="submit" className="w-full">
+            View Conversation
+          </Button>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default async function Home({ searchParams }: HomeProps) {
+  const appMode = getAppMode()
+  const params = searchParams ? await searchParams : undefined
+  const rawObservedUserId = params?.userId
+  const observedUserIdResult =
+    appMode === "observe"
+      ? parseObservedUserId(rawObservedUserId)
+      : { userId: null as number | null }
+  const observedUserId = observedUserIdResult.userId
+  const hasRequestedObservedUserId =
+    typeof rawObservedUserId === "string"
+      ? rawObservedUserId.trim().length > 0
+      : Array.isArray(rawObservedUserId)
+        ? rawObservedUserId.some((value) => value.trim().length > 0)
+        : false
+  const shouldFetchMessages = appMode === "chat" || observedUserId !== null
+
+  const response = shouldFetchMessages
+    ? await getMessages(
+        appMode === "observe" ? { userId: observedUserId ?? undefined } : {}
+      )
+    : { messages: [], error: undefined }
   const { messages = [], error } = response
+
+  if (appMode === "observe" && observedUserId === null) {
+    return (
+      <ObserveUserLookup
+        error={
+          hasRequestedObservedUserId ? observedUserIdResult.error : undefined
+        }
+        userIdValue={
+          typeof rawObservedUserId === "string" ? rawObservedUserId : undefined
+        }
+      />
+    )
+  }
 
   return (
     <Suspense
@@ -22,6 +103,8 @@ export default async function Home() {
       <ClientChatInterface
         initialMessages={messages}
         isInitialLoading={!!error}
+        mode={appMode}
+        observedUserId={observedUserId}
       />
     </Suspense>
   )

--- a/components/ClientChatInterface.tsx
+++ b/components/ClientChatInterface.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useRef, useState } from "react"
+import Link from "next/link"
 import {
   AlertCircle,
   Database,
@@ -28,12 +29,17 @@ import { sendWhatsAppMessage } from "@/app/actions/whatsapp"
 interface ClientChatInterfaceProps {
   initialMessages: Message[]
   isInitialLoading?: boolean
+  mode?: "chat" | "observe"
+  observedUserId?: number | null
 }
 
 export default function ClientChatInterface({
   initialMessages,
   isInitialLoading = false,
+  mode = "chat",
+  observedUserId = null,
 }: ClientChatInterfaceProps) {
+  const isReadOnly = mode === "observe"
   // Use initialMessages as the starting point for our state
   const [messages, setMessages] = useState<Message[]>(initialMessages)
   const [isLoading, setIsLoading] = useState(isInitialLoading)
@@ -53,7 +59,11 @@ export default function ClientChatInterface({
 
     try {
       setIsLoading(true)
-      const response = await getMessages()
+      const response = await getMessages(
+        isReadOnly && observedUserId !== null
+          ? { userId: observedUserId }
+          : undefined
+      )
       setIsLoading(false)
 
       if (response.error) {
@@ -164,6 +174,11 @@ export default function ClientChatInterface({
   }
 
   const handleSendMessage = (text: string) => {
+    if (isReadOnly) {
+      setDbError("Observe mode is read-only. Sending is disabled.")
+      return
+    }
+
     // If we have a connection error, prevent sending
     if (connectionFailed) {
       // Show a temporary error that sending is disabled
@@ -262,9 +277,19 @@ export default function ClientChatInterface({
           <div className="flex size-10 items-center justify-center rounded-full bg-muted">
             <span className="text-lg font-semibold text-primary">T</span>
           </div>
-          <h1 className="text-xl font-semibold text-primary-foreground">
-            Twiga
-          </h1>
+          <div className="flex flex-col">
+            <h1 className="text-xl font-semibold text-primary-foreground">
+              Twiga
+            </h1>
+            {isReadOnly && observedUserId !== null ? (
+              <div className="flex items-center gap-2 text-xs text-primary-foreground/80">
+                <span className="rounded-full bg-primary-foreground/15 px-2 py-0.5 uppercase tracking-[0.2em]">
+                  Observe
+                </span>
+                <span>User #{observedUserId}</span>
+              </div>
+            ) : null}
+          </div>
           {/* Database status indicator */}
           {connectionFailed ? (
             <div className="flex items-center rounded-full bg-red-500 px-2 py-0.5 text-xs text-white">
@@ -287,9 +312,16 @@ export default function ClientChatInterface({
               <RefreshCw className="mr-2 size-4" />
               Refresh
             </DropdownMenuItem>
-            <DropdownMenuItem onClick={handleClearChat}>
-              Clear chat
-            </DropdownMenuItem>
+            {!isReadOnly ? (
+              <DropdownMenuItem onClick={handleClearChat}>
+                Clear chat
+              </DropdownMenuItem>
+            ) : null}
+            {isReadOnly ? (
+              <DropdownMenuItem asChild>
+                <Link href="/">Change observed user</Link>
+              </DropdownMenuItem>
+            ) : null}
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
@@ -328,9 +360,13 @@ export default function ClientChatInterface({
         ) : combinedMessages.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center text-muted-foreground">
             <MessageSquare className="mb-4 size-12 opacity-20" />
-            <h3 className="mb-1 text-lg font-medium">No messages yet</h3>
+            <h3 className="mb-1 text-lg font-medium">
+              {isReadOnly ? "No conversation found" : "No messages yet"}
+            </h3>
             <p className="text-center text-sm">
-              Start a conversation by sending a message below
+              {isReadOnly && observedUserId !== null
+                ? `No visible user or assistant messages were found for user #${observedUserId}.`
+                : "Start a conversation by sending a message below"}
             </p>
           </div>
         ) : (
@@ -351,17 +387,24 @@ export default function ClientChatInterface({
       </div>
 
       {/* Input area */}
-      <div className="p-4">
-        <ChatInput
-          onSendMessage={handleSendMessage}
-          disabled={connectionFailed}
-          placeholder={
-            connectionFailed
-              ? "Database connection required to send messages"
-              : "Type a message..."
-          }
-        />
-      </div>
+      {isReadOnly ? (
+        <div className="border-t bg-muted/40 px-4 py-3 text-sm text-muted-foreground">
+          Observe mode is read-only. This view only loads conversation history
+          from the database.
+        </div>
+      ) : (
+        <div className="p-4">
+          <ChatInput
+            onSendMessage={handleSendMessage}
+            disabled={connectionFailed}
+            placeholder={
+              connectionFailed
+                ? "Database connection required to send messages"
+                : "Type a message..."
+            }
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,6 +1,7 @@
 import { sql } from "drizzle-orm"
 import {
   boolean,
+  integer,
   pgTable,
   serial,
   text,
@@ -20,6 +21,7 @@ export type MessageRoleType = (typeof MessageRole)[keyof typeof MessageRole]
 // Messages table matching the SQLModel structure
 export const messages = pgTable("messages", {
   id: serial("id").primaryKey(),
+  user_id: integer("user_id"),
   role: varchar("role", { length: 20 }).notNull(),
   content: text("content"),
   tool_name: varchar("tool_name", { length: 255 }),

--- a/lib/appMode.test.ts
+++ b/lib/appMode.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { getAppMode, parseObservedUserId } from "@/lib/appMode"
+
+test("getAppMode defaults to chat", () => {
+  assert.equal(getAppMode(undefined), "chat")
+})
+
+test("getAppMode returns observe when configured", () => {
+  assert.equal(getAppMode("observe"), "observe")
+})
+
+test("parseObservedUserId accepts positive integer strings", () => {
+  assert.deepEqual(parseObservedUserId("42"), { userId: 42 })
+})
+
+test("parseObservedUserId ignores empty values", () => {
+  assert.deepEqual(parseObservedUserId(undefined), { userId: null })
+  assert.deepEqual(parseObservedUserId(""), { userId: null })
+})
+
+test("parseObservedUserId rejects non-numeric values", () => {
+  assert.deepEqual(parseObservedUserId("abc"), {
+    userId: null,
+    error: "Enter a positive numeric user ID.",
+  })
+})
+
+test("parseObservedUserId rejects non-positive values", () => {
+  assert.deepEqual(parseObservedUserId("0"), {
+    userId: null,
+    error: "Enter a positive numeric user ID.",
+  })
+})

--- a/lib/appMode.ts
+++ b/lib/appMode.ts
@@ -1,0 +1,34 @@
+export type AppMode = "chat" | "observe"
+
+export function getAppMode(appMode = process.env.APP_MODE): AppMode {
+  return appMode === "observe" ? "observe" : "chat"
+}
+
+export function parseObservedUserId(rawUserId: string | string[] | undefined): {
+  userId: number | null
+  error?: string
+} {
+  const value = Array.isArray(rawUserId) ? rawUserId[0] : rawUserId
+
+  if (!value) {
+    return { userId: null }
+  }
+
+  if (!/^\d+$/.test(value)) {
+    return {
+      userId: null,
+      error: "Enter a positive numeric user ID.",
+    }
+  }
+
+  const userId = Number(value)
+
+  if (!Number.isSafeInteger(userId) || userId <= 0) {
+    return {
+      userId: null,
+      error: "Enter a positive numeric user ID.",
+    }
+  }
+
+  return { userId }
+}

--- a/lib/messageQuery.test.ts
+++ b/lib/messageQuery.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  buildMessagesFindManyOptions,
+  formatDbMessage,
+} from "@/lib/messageQuery"
+
+const fakeColumns = {
+  is_present_in_conversation: "is_present_in_conversation",
+  role: "role",
+  user_id: "user_id",
+  created_at: "created_at",
+}
+
+const fakeOperators = {
+  and: (...args: unknown[]) => ({ type: "and", args }),
+  eq: (column: string, value: unknown) => ({ type: "eq", column, value }),
+  or: (...args: unknown[]) => ({ type: "or", args }),
+  desc: (column: string) => ({ type: "desc", column }),
+}
+
+test("buildMessagesFindManyOptions keeps the conversation visibility filters", () => {
+  const options = buildMessagesFindManyOptions()
+
+  assert.equal(options.limit, 100)
+  assert.deepEqual(options.where(fakeColumns, fakeOperators), {
+    type: "and",
+    args: [
+      {
+        type: "eq",
+        column: "is_present_in_conversation",
+        value: true,
+      },
+      {
+        type: "or",
+        args: [
+          { type: "eq", column: "role", value: "user" },
+          { type: "eq", column: "role", value: "assistant" },
+        ],
+      },
+    ],
+  })
+  assert.deepEqual(options.orderBy(fakeColumns, fakeOperators), [
+    { type: "desc", column: "created_at" },
+  ])
+})
+
+test("buildMessagesFindManyOptions adds a user_id filter when observing a user", () => {
+  const options = buildMessagesFindManyOptions({ limit: 25, userId: 7 })
+
+  assert.equal(options.limit, 25)
+  assert.deepEqual(options.where(fakeColumns, fakeOperators), {
+    type: "and",
+    args: [
+      {
+        type: "eq",
+        column: "is_present_in_conversation",
+        value: true,
+      },
+      {
+        type: "or",
+        args: [
+          { type: "eq", column: "role", value: "user" },
+          { type: "eq", column: "role", value: "assistant" },
+        ],
+      },
+      {
+        type: "eq",
+        column: "user_id",
+        value: 7,
+      },
+    ],
+  })
+})
+
+test("formatDbMessage preserves the observed user id", () => {
+  const createdAt = new Date("2025-01-02T03:04:05.000Z")
+
+  assert.deepEqual(
+    formatDbMessage({
+      id: 10,
+      user_id: 99,
+      role: "assistant",
+      content: "Hello",
+      tool_name: null,
+      is_present_in_conversation: true,
+      created_at: createdAt,
+    }),
+    {
+      id: 10,
+      user_id: 99,
+      role: "assistant",
+      content: "Hello",
+      tool_name: null,
+      created_at: createdAt,
+      timestamp: Math.floor(createdAt.getTime() / 1000),
+      status: "sent",
+    }
+  )
+})

--- a/lib/messageQuery.ts
+++ b/lib/messageQuery.ts
@@ -1,0 +1,47 @@
+import { type Message as DbMessage } from "@/db/schema"
+import { type Message } from "@/types/chat"
+
+export interface GetMessagesOptions {
+  limit?: number
+  userId?: number
+}
+
+export function buildMessagesFindManyOptions({
+  limit = 100,
+  userId,
+}: GetMessagesOptions = {}) {
+  const shouldFilterByUserId =
+    typeof userId === "number" && Number.isSafeInteger(userId) && userId > 0
+
+  return {
+    limit,
+    where: (messages: any, { and, eq, or }: any) => {
+      const filters = [
+        eq(messages.is_present_in_conversation, true),
+        or(eq(messages.role, "user"), eq(messages.role, "assistant")),
+      ]
+
+      if (shouldFilterByUserId) {
+        filters.push(eq(messages.user_id, userId))
+      }
+
+      return and(...filters)
+    },
+    orderBy: (messages: any, { desc }: any) => [desc(messages.created_at)],
+  }
+}
+
+export function formatDbMessage(message: DbMessage): Message {
+  return {
+    id: message.id ?? crypto.randomUUID(),
+    user_id: message.user_id ?? undefined,
+    role: message.role as Message["role"],
+    content: message.content ?? "",
+    tool_name: message.tool_name ?? null,
+    created_at: message.created_at,
+    timestamp: message.created_at
+      ? Math.floor(new Date(message.created_at).getTime() / 1000)
+      : Math.floor(Date.now() / 1000),
+    status: "sent",
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "clean": "rimraf --glob **/node_modules **/dist **/.next pnpm-lock.yaml **/.tsbuildinfo",
     "build": "next build && cp -r public .next/standalone/ && cp -r .next/static .next/standalone/.next/",
     "dev": "next dev",
+    "observe": "APP_MODE=observe next dev",
     "start": "cd .next/standalone && node server.js",
     "lint": "next lint",
     "lint:fix": "next lint --fix",


### PR DESCRIPTION
This change introduces an `observe` runtime mode for the mock WhatsApp app so internal teams can inspect the visible conversation history for a specific user directly from the database, in a more friendly format. The motivation is internal tracking of user experience and usage: it gives us a safe way to review how a given user’s journey was. In observe mode, the app scopes the chat to a selected `user_id`, still respects the `is_present_in_conversation` flag. This new part is strictly read-only.

To test it, start the app normally with `pnpm run dev` and confirm the existing chat flow still behaves as before, including the ability to send messages. Then start the app with `pnpm run observe`, enter a known numeric user ID, and verify that the UI loads only that user’s visible `user` and `assistant` messages from the database. Confirm that no message composer is available in this mode, that no send action can be triggered from the interface, and that switching the observed user reloads the conversation history for the newly selected user without mutating any data.